### PR TITLE
Add Travis-CI build instructions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
  - pip install fypp
 
 script:
- - mkdir -p _build && pushd _build && cmake -DMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} .. && make -j && popd
+ - mkdir -p _build && pushd _build && cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} .. && make -j && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
  - pip install fypp
 
 script:
- - mkdir -p _build && pushd _build && cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} .. && make -j && popd
+ - mkdir -p _build && pushd _build && cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DEXTERNAL_LIBRARIES="scalapack-openmpi;lapack;blas" .. && make -j && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+os: linux
+dist: bionic
+
+language: python
+python: 3.7
+
+
+env:
+ - BUILD_SHARED_LIBS=false
+ - BUILD_SHARED_LIBS=true
+
+addons:
+   apt:
+      packages:
+      - cmake
+      - gfortran
+      - libblas-dev
+      - liblapack-dev
+      - libopenmpi-dev
+      - libscalapack-openmpi-dev
+
+install:
+ - pip install fypp
+
+script:
+ - mkdir -p _build && pushd _build && cmake -DMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} .. && make -j && popd


### PR DESCRIPTION
[![Build Status](https://travis-ci.com/awvwgk/scalapackfx.svg?branch=travis-ci)](https://travis-ci.com/awvwgk/scalapackfx)

Currently failing in the link line as `-lscalpack` is not picked up correctly.

Maybe a patch like this should be applied as well?

```patch
diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
index e135098..10141ca 100644
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ foreach(fppsrc IN LISTS sources-fpp)
 endforeach()
 
 add_library(scalapackfx ${SOURCES-F90-PREPROC})
+target_link_libraries(scalapackfx ${EXTERNAL_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 set(BUILD_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 
```