### PR TITLE
Use complex alpha in Hermitian rank-2k interface

### DIFF
--- a/lib/pblas.fpp
+++ b/lib/pblas.fpp
@@ -64,7 +64,7 @@
     import
     character, intent(in) :: uplo, trans
     integer, intent(in) :: nn, kk
-    real(${KIND}$), intent(in) :: alpha
+    ${TYPE}$(${KIND}$), intent(in) :: alpha
     integer, intent(in) :: desca(*)
     ${TYPE}$(${KIND}$), intent(in) :: aa(desca(LLD_), *)
     integer, intent(in) :: ia, ja

--- a/lib/pblasfx.fpp
+++ b/lib/pblasfx.fpp
@@ -162,15 +162,17 @@
     ${TYPE}$(${KIND}$), intent(inout) :: cc(:,:)
     integer, intent(in) :: descc(DLEN_)
     character, intent(in), optional :: uplo, trans
-    real(${KIND}$), intent(in), optional :: alpha, beta
+    ${TYPE}$(${KIND}$), intent(in), optional :: alpha
+    real(${KIND}$), intent(in), optional :: beta
     integer, intent(in), optional :: nn, kk
     integer, intent(in), optional :: ia, ja, ib, jb, ic, jc
 
-    real(${KIND}$) :: alpha0, beta0
+    ${TYPE}$(${KIND}$) :: alpha0
+    real(${KIND}$) :: beta0
     character :: uplo0, trans0
     integer :: nn0, kk0, ia0, ja0, ib0, jb0, ic0, jc0
 
-    @:inoptflags(alpha0, alpha, real(1, kind=${KIND}$))
+    @:inoptflags(alpha0, alpha, ${FUNCTION}$(1, kind=${KIND}$))
     @:inoptflags(beta0, beta, real(0, kind=${KIND}$))
     @:inoptflags(uplo0, uplo, "L")
     @:inoptflags(trans0, trans, "N")


### PR DESCRIPTION
The shared `psyr2k`/`pher2k` interface template declares the `alpha`
prefactor as `real`, but `pcher2k`/`pzher2k` take a **complex** `alpha`
(only `beta` is real in the Hermitian rank-2k update). Passing an 8-byte
real where the library reads a 16-byte complex leaves the imaginary part
of `alpha` undefined.

This declares `alpha` with the template's own `TYPE` — `real` for
`psyr2k`, `complex` for `pher2k` — so the public `pblasfx_pher2k` API
matches the ScaLAPACK convention and takes a complex `alpha` directly
rather than converting from a real one. `beta` stays real. The `psyr2k`
real path expands byte-for-byte identically.

This is an intentional signature change for the complex generic
(`alpha`: real → complex) with no deprecation shim: the old real-`alpha`
path silently dropped the imaginary part, so no correct caller could have
relied on it. `pher2k`/`psyr2k` have no in-tree callers.

One item from #49.

Verified with Intel oneAPI 2025.3 + MKL ScaLAPACK: a complex-`alpha`
`pblasfx_pher2k` on a 1×1 grid reproduces the `?her2k` definition exactly
and differs from the old real-truncated result; the existing test suite,
including the real `psyr` path, is unchanged.
