### PR TITLE
Correct output matrix intent in psymm/phemm interface

### DIFF
--- a/lib/pblas.fpp
+++ b/lib/pblas.fpp
@@ -134,7 +134,7 @@
     ${TYPE}$(${KIND}$), intent(in) :: bb(descb(LLD_), *)
     integer, intent(in) :: ib, jb
     integer, intent(in) :: descc(*)
-    ${TYPE}$(${KIND}$), intent(in) :: cc(descc(LLD_), *)
+    ${TYPE}$(${KIND}$), intent(inout) :: cc(descc(LLD_), *)
     integer, intent(in) :: ic, jc
   end subroutine ${NAME}$
 


### PR DESCRIPTION
The symmetric/Hermitian matrix–matrix product routines write their result
into `cc`, but the low-level interface declared `cc` as `intent(in)`. A
compiler may assume an `intent(in)` argument is unchanged across the call
and elide the update. Declare `cc` `intent(inout)`, matching the `pblasfx`
wrapper, which already declares it `inout`.

One of the smaller items from #49. No behavioral change for correct
callers; latent (no in-tree callers of `psymm`/`phemm`).
