### PR TITLE
Take pgemm output leading dimension from descc

### DIFF
--- a/lib/pblas.fpp
+++ b/lib/pblas.fpp
@@ -186,7 +186,7 @@
     integer, intent(in) :: ib, jb
     ${TYPE}$(${KIND}$), intent(in) :: beta
     integer, intent(in) :: descc(*)
-    ${TYPE}$(${KIND}$), intent(inout) :: cc(descb(LLD_), *)
+    ${TYPE}$(${KIND}$), intent(inout) :: cc(descc(LLD_), *)
     integer, intent(in) :: ic, jc
   end subroutine ${NAME}$
 


### PR DESCRIPTION
The general matrix–matrix product interface declared the output matrix
`cc` with its leading dimension taken from `descb` (the descriptor of `B`)
instead of `descc`, its own descriptor. When `B` and `C` have different
local leading dimensions, the dummy argument's declared shape is wrong.

One of the smaller items from #49. The in-tree callers (`test_pposv`,
`test_matinv`) pass a single shared descriptor for all operands, so the
mismatch was masked; both still pass with this change.
